### PR TITLE
Git Ignore Storage Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /public/hot
 /public/storage
+/storage
 /storage/*.key
 /storage/database.sqlite
 /vendor


### PR DESCRIPTION
Chown for app use prevents modifying .gitingore files inside storage directory.